### PR TITLE
Use munki's python framework shebang

### DIFF
--- a/public/assets/client_installer/payload/usr/local/munki/postflight
+++ b/public/assets/client_installer/payload/usr/local/munki/postflight
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/munki/python
 
 import os
 import subprocess


### PR DESCRIPTION
`#!/usr/bin/python` should be swapped to point to the `#!/usr/local/munki/python`.